### PR TITLE
use correct framework

### DIFF
--- a/org.igrok.validator.test.netcore/org.igrok.validator.test.netcore.csproj
+++ b/org.igrok.validator.test.netcore/org.igrok.validator.test.netcore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net80</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/org.igrok.validator/org.igrok.validator.csproj
+++ b/org.igrok.validator/org.igrok.validator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net80;netstandard2.0;net40;</TargetFrameworks>
+    <TargetFrameworks>net8.0;netstandard2.0;net40;</TargetFrameworks>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Description>Validators for data types that are not available in c# apis</Description>
     <Copyright>Oleg Golovchenko</Copyright>


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) [learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks)